### PR TITLE
Allow WooCommerce Blocks checkout to create sequential order number

### DIFF
--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -99,6 +99,8 @@ class WC_Seq_Order_Number {
 		add_action( 'wp_insert_post', array( $this, 'set_sequential_order_number' ), 10, 2 );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'set_sequential_order_number' ), 10, 2 );
 
+		add_action( 'woocommerce_store_api_checkout_update_order_meta', array( $this, 'set_sequential_order_number' ), 10, 2 );
+
 		// return our custom order number for display
 		add_filter( 'woocommerce_order_number', array( $this, 'get_order_number' ), 10, 2 );
 


### PR DESCRIPTION
Fixes #31 

Currently, WooCommerce Blocks checkout block is not compatible with the plugin.  The WooCommerce Blocks checkout block uses `woocommerce_store_api_checkout_update_order_meta` action when the order meta is updated during checkout.  This PR adds `set_sequential_order_number` to the blocks checkout action to update the order number format.


### Testing instruction
1. Go WooCommerce -> settings -> Order Number Format
2. Set the Prefix and Suffix
3. Create a page using Block checkout
4. As a shopper, checkout with Block checkout
5. See the order number with prefix and suffix