### PR TITLE
HPOS support in Sequential Order Numbers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.toml,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt}]
+end_of_line = crlf

--- a/readme.txt
+++ b/readme.txt
@@ -103,8 +103,8 @@ $order_number = $order->get_order_number();
 == Changelog ==
 
 - 2023.nn.nn - version 1.10.0-dev.1 =
- * Tweak - Add support for WooCommerce Blocks checkout
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
+ * Misc - Add support for WooCommerce Blocks checkout
  * Misc - Require PHP 7.4 and WordPress 5.6
 
 = 2022.07.30 - version 1.9.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ $order_number = $order->get_order_number();
 == Changelog ==
 
 - 2023.nn.nn - version 1.10.0-dev.1 =
+ * Tweak - Add support for WooCommerce Blocks checkout
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
  * Misc - Require PHP 7.4 and WordPress 5.6
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,10 @@ $order_number = $order->get_order_number();
 
 == Changelog ==
 
+- 2023.nn.nn - version 1.10.0-dev.1 =
+ * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
+ * Misc - Require PHP 7.4 and WordPress 5.6
+
 = 2022.07.30 - version 1.9.7 =
  * Misc - Rename to Sequential Order Numbers for WooCommerce
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,8 +103,8 @@ $order_number = $order->get_order_number();
 == Changelog ==
 
 - 2023.nn.nn - version 1.10.0-dev.1 =
+ * Tweak - Also set sequential order numbers for orders sent via the WooCommerce Checkout Block
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
- * Misc - Add support for WooCommerce Checkout Block
  * Misc - Require PHP 7.4 and WordPress 5.6
 
 = 2022.07.30 - version 1.9.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,9 @@
 === Sequential Order Numbers for WooCommerce ===
 Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
-Requires at least: 4.7
+Requires at least: 5.6
 Tested up to: 6.0.1
+Requires PHP: 7.4
 Stable tag: 1.10.0-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.7
 Tested up to: 6.0.1
-Stable tag: 1.9.7
+Stable tag: 1.10.0-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 

--- a/readme.txt
+++ b/readme.txt
@@ -104,7 +104,7 @@ $order_number = $order->get_order_number();
 
 - 2023.nn.nn - version 1.10.0-dev.1 =
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
- * Misc - Add support for WooCommerce Blocks checkout
+ * Misc - Add support for WooCommerce Checkout Block
  * Misc - Require PHP 7.4 and WordPress 5.6
 
 = 2022.07.30 - version 1.9.7 =

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -182,8 +182,8 @@ class WC_Seq_Order_Number {
 		add_filter( 'woocommerce_shortcode_order_tracking_order_id', array( $this, 'find_order_by_order_number' ) );
 
 		// WC Subscriptions support
-		add_filter( 'wcs_renewal_order_meta_query', array( $this, 'subscriptions_remove_renewal_order_meta' ) );
-		add_filter( 'wcs_renewal_order_created',    array( $this, 'subscriptions_set_sequential_order_number' ), 10, 2 );
+		add_filter( 'wc_subscriptions_renewal_order_data', [ $this, 'subscriptions_remove_renewal_order_meta' ] );
+		add_filter( 'wcs_renewal_order_created',           [ $this, 'subscriptions_set_sequential_order_number' ], 10, 2 );
 
 		// WooCommerce Admin support
 		if ( class_exists( 'Automattic\WooCommerce\Admin\Install', false ) || class_exists( 'WC_Admin_Install', false ) ) {
@@ -491,11 +491,18 @@ class WC_Seq_Order_Number {
 	 *
 	 * @internal
 	 *
-	 * @param string $order_meta_query query for pulling the metadata
-	 * @return string
+	 * @param string[]|mixed $order_data
+	 * @return string[]mixed
 	 */
-	public function subscriptions_remove_renewal_order_meta( $order_meta_query ) {
-		return $order_meta_query . " AND meta_key NOT IN ( '_order_number' )";
+	public function subscriptions_remove_renewal_order_meta( $order_data ) {
+
+		if ( ! is_array( $order_data ) ) {
+			return $order_data;
+		}
+
+		unset( $order_data['_order_number'] );
+
+		return $order_data;
 	}
 
 	/**

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -185,6 +185,8 @@ class WC_Seq_Order_Number {
 	/**
 	 * Search for an order with order_number $order_number
 	 *
+	 * @internal
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $order_number order number to search for
@@ -240,6 +242,8 @@ class WC_Seq_Order_Number {
 
 	/**
 	 * Set the _order_number field for the newly created order
+	 *
+	 * @internal
 	 *
 	 * @since 1.0.0
 	 *
@@ -334,7 +338,9 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Admin order table orderby ID operates on our meta _order_number
+	 * Admin order table orderby ID operates on our meta `_order_number`.
+	 *
+	 * @internal
 	 *
 	 * @param array $vars associative array of orderby parameteres
 	 * @return array associative array of orderby parameteres
@@ -351,9 +357,12 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Mofifies the given $args argument to sort on our meta integral _order_number
+	 * Modifies the given $args argument to sort on our` _order_number` meta.
+	 *
+	 * @internal
 	 *
 	 * @since 1.3
+	 *
 	 * @param array $args associative array of orderby parameteres
 	 * @return array associative array of orderby parameteres
 	 */
@@ -373,8 +382,11 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Add our custom _order_number to the set of search fields so that
-	 * the admin search functionality is maintained
+	 * Add our custom `_order_number` to the set of search fields so that the admin search functionality is maintained.
+	 *
+	 * @internal
+	 *
+	 * @since 1.0.0
 	 *
 	 * @param array $search_fields array of post meta fields to search by
 	 * @return array of post meta fields to search by

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -315,7 +315,7 @@ class WC_Seq_Order_Number {
 
 			$order        = $object instanceof \WC_Order ? $object : wc_get_order( (int) $order_id );
 			$is_order     = $order instanceof \WC_Order && 'shop_order' === $order->get_type();
-			$order_id     = $order ? $order->get_id() : 0;
+			$order_id     = ! $order_id && $order ? $order->get_id() : (int) $order_id;
 			$order_status = $order ? $order->get_status() : '';
 
 			if ( $is_order && $order_status !== 'auto-draft' && isset( $_GET['action'] ) && $_GET['action'] === 'new' ) {

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -197,7 +197,7 @@ class WC_Seq_Order_Number {
 			if ( $this->is_hpos_enabled() ) {
 				/** @see \Automattic\WooCommerce\Internal\Admin\Orders\ListTable::prepare_items() */
 				add_filter( 'woocommerce_shop_order_list_table_request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
-				add_filter('woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_admin_order_search_by_order_number' ] );
+				add_filter( 'woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_admin_order_table_search_by_order_number' ] );
 			} else {
 				add_filter( 'request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
 			}
@@ -425,15 +425,15 @@ class WC_Seq_Order_Number {
 	 * @param array<string, mixed>|mixed $order_args
 	 * @return array<string, mixed>|mixed
 	 */
-	public function filter_admin_order_search_by_order_number( $order_args ) {
+	public function filter_admin_order_table_search_by_order_number( $order_args ) {
 
 		if ( ! is_array( $order_args ) ) {
 			return $order_args;
 		}
 
-		if (isset($order_args['s']) && is_numeric($order_args['s'])) {
+		if ( isset( $order_args['s'] ) && is_numeric( $order_args['s'] ) ) {
 
-			$order = wc_get_order([
+			$order = wc_get_order( [
 				'fields'     => 'ids',
 				'limit'      => 1,
 				'meta_query' => [
@@ -441,10 +441,10 @@ class WC_Seq_Order_Number {
 					'value'   => (int) $order_args['s'],
 					'compare' => '='
 				]
-			]);
+			] );
 
 			// if we find an order matching the order number from search, let's use this order ID instead
-			if ($order) {
+			if ( $order ) {
 				$order_args['s'] = $order[0];
 			}
 		}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -231,9 +231,7 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Search for an order with order_number $order_number
-	 *
-	 * @internal
+	 * Search for an order having a given order number.
 	 *
 	 * @since 1.0.0
 	 *

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -327,7 +327,7 @@ class WC_Seq_Order_Number {
 		}
 
 		// when creating an order from the admin don't create order numbers for auto-draft orders,
-		// because these are not linked to from the admin and so difficult to delete
+		// because these are not linked to from the admin and so difficult to delete when CPT tables are used
 		if ( $object === null || ( $is_order && ( $using_hpos || 'auto-draft' !== $order_status ) ) ) {
 
 			if ( $using_hpos ) {

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -368,8 +368,9 @@ class WC_Seq_Order_Number {
 					", $wpdb->insert_id ) );
 
 					$order->update_meta_data( '_order_number', $order_number );
-					$order->save();
 				}
+
+				$order->save();
 			}
 		}
 	}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -147,8 +147,7 @@ class WC_Seq_Order_Number {
 		add_filter( 'wcs_renewal_order_created',    array( $this, 'subscriptions_set_sequential_order_number' ), 10, 2 );
 
 		// WooCommerce Admin support
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Install', false ) ||
-		     class_exists( 'WC_Admin_Install', false ) ) {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Install', false ) || class_exists( 'WC_Admin_Install', false ) ) {
 			add_filter( 'woocommerce_rest_orders_prepare_object_query', array( $this, 'wc_admin_order_number_api_param' ), 10, 2 );
 		}
 
@@ -388,14 +387,12 @@ class WC_Seq_Order_Number {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $search_fields array of post meta fields to search by
-	 * @return array of post meta fields to search by
+	 * @param string[] $search_fields array of post meta fields to search by
+	 * @return string[] of post meta fields to search by
 	 */
 	public function custom_search_fields( $search_fields ) {
 
-		array_push( $search_fields, '_order_number' );
-
-		return $search_fields;
+		return array_merge( (array) $search_fields, [ '_order_number' ] );
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -449,7 +449,7 @@ class WC_Seq_Order_Number {
 	 */
 	public function custom_search_fields( $search_fields ) {
 
-		return array_merge( (array) $search_fields, [ '_order_number' ] );
+		return array_merge( (array) $search_fields, [ '_order_number', 'order_number' ] );
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -166,7 +166,9 @@ class WC_Seq_Order_Number {
 		}
 
 		// set the custom order number on the new order
-		add_action( 'wp_insert_post',                         [ $this, 'set_sequential_order_number' ], 10, 2 );
+		if ( ! $this->is_hpos_enabled() ) {
+			add_action( 'wp_insert_post', [ $this, 'set_sequential_order_number' ], 10, 2 );
+		}
 		add_action( 'woocommerce_checkout_update_order_meta', [ $this, 'set_sequential_order_number' ], 10, 2 );
 		add_action( 'woocommerce_process_shop_order_meta',    [ $this, 'set_sequential_order_number' ], 35, 2 );
 		add_action( 'woocommerce_before_resend_order_emails', [ $this, 'set_sequential_order_number' ] );
@@ -699,7 +701,7 @@ class WC_Seq_Order_Number {
 
 					// Translators: %s - error message(s)
 					wp_die( sprintf( __( 'Error activating and installing <strong>Sequential Order Numbers for WooCommerce</strong>: %s', 'woocommerce-sequential-order-numbers' ), '<ul><li>' . implode( '</li><li>', $order_ids->get_error_messages() ) . '</li></ul>' ) .
-					        '<a href="' . admin_url( 'plugins.php' ) . '">' . __( '&laquo; Go Back', 'woocommerce-sequential-order-numbers' ) . '</a>' );
+							'<a href="' . admin_url( 'plugins.php' ) . '">' . __( '&laquo; Go Back', 'woocommerce-sequential-order-numbers' ) . '</a>' );
 				}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -433,13 +433,15 @@ class WC_Seq_Order_Number {
 
 		if ( isset( $order_args['s'] ) && is_numeric( $order_args['s'] ) ) {
 
-			$order = wc_get_order( [
-				'fields'     => 'ids',
+			$order = wc_get_orders( [
+				'return'     => 'ids',
 				'limit'      => 1,
 				'meta_query' => [
-					'key'     => '_order_number',
-					'value'   => (int) $order_args['s'],
-					'compare' => '='
+					[
+						'key'     => '_order_number',
+						'value'   => $order_args['s'],
+						'compare' => '='
+					],
 				]
 			] );
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -314,7 +314,7 @@ class WC_Seq_Order_Number {
 		} else {
 
 			$order        = $object instanceof \WC_Order ? $object : wc_get_order( (int) $order_id );
-			$is_order     = $order instanceof \WC_Order && ! $order instanceof \WC_Subscription;
+			$is_order     = $order instanceof \WC_Order && 'shop_order' === $order->get_type();
 			$order_id     = $order ? $order->get_id() : 0;
 			$order_status = $order ? $order->get_status() : '';
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -295,7 +295,7 @@ class WC_Seq_Order_Number {
 	 * @since 1.0.0
 	 *
 	 * @param int|\WC_Order $order_id order identifier or order object
-	 * @param \WP_Post|\WC_Order|array<string, mixed>null $object order or post object or post data (depending on HPOS and hook in use)
+	 * @param \WP_Post|\WC_Order|array<string, mixed>|null $object $object order or post object or post data (depending on HPOS and hook in use)
 	 */
 	public function set_sequential_order_number( $order_id = null, $object = null ) {
 		global $wpdb;

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -403,8 +403,8 @@ class WC_Seq_Order_Number {
 	 *
 	 * @since 1.3
 	 *
-	 * @param array $vars associative array of orderby parameteres
-	 * @return array associative array of orderby parameteres
+	 * @param array $vars associative array of orderby parameters
+	 * @return array associative array of orderby parameters
 	 */
 	public function woocommerce_custom_shop_order_orderby( $vars ) {
 		global $typenow;
@@ -435,18 +435,18 @@ class WC_Seq_Order_Number {
 	 *
 	 * @since 1.3
 	 *
-	 * @param array $args associative array of orderby parameteres
-	 * @return array associative array of orderby parameteres
+	 * @param array $args associative array of orderby parameters
+	 * @return array associative array of orderby parameters
 	 */
 	public function custom_orderby( $args ) {
 
-		// Sorting
+		// sorting
 		if ( isset( $args['orderby'] ) && 'ID' == $args['orderby'] ) {
 
-			$args = array_merge( $args, array(
+			$args = array_merge( $args, [
 				'meta_key' => '_order_number',  // sort on numerical portion for better results
 				'orderby'  => 'meta_value_num',
-			) );
+			] );
 		}
 
 		return $args;

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -314,7 +314,7 @@ class WC_Seq_Order_Number {
 		} else {
 
 			$order        = $object instanceof \WC_Order ? $object : wc_get_order( (int) $order_id );
-			$is_order     = $order instanceof \WC_Order;
+			$is_order     = $order instanceof \WC_Order && ! $order instanceof \WC_Subscription;
 			$order_id     = $order ? $order->get_id() : 0;
 			$order_status = $order ? $order->get_status() : '';
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -251,6 +251,7 @@ class WC_Seq_Order_Number {
 					[
 						'key'        => '_order_number',
 						'value'      => $order_number,
+						'comparison' => '='
 					],
 				],
 			]);

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -356,20 +356,8 @@ class WC_Seq_Order_Number {
 					", (int) $order_id ) );
 				}
 
-				// With HPOS we need to trigger a save to update the order number or it won't persist by using the direct query above alone.
-				// This may have the effect of creating 2 identical order number meta entries for an order but this seems to work nonetheless.
-				if ( $success && $using_hpos ) {
-
-					$meta_id_col  = 'id';
-					$order_number = $wpdb->get_var( $wpdb->prepare( "
-						SELECT meta_value
-						FROM {$order_meta_table}
-						WHERE {$meta_id_col} = %d
-					", $wpdb->insert_id ) );
-
-					$order->update_meta_data( '_order_number', $order_number );
-					$order->save();
-				}
+				// with HPOS we need to trigger a save to update the order number, otherwise it won't persist by using the direct query above alone
+				$order->save();
 			}
 		}
 	}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -395,12 +395,13 @@ class WC_Seq_Order_Number {
 
 		if ( $renewal_order instanceof WC_Order ) {
 
-			$order_post = get_post( $renewal_order->get_id() );
+			$order = wc_get_order( $renewal_order->get_id() );
 
-			$this->set_sequential_order_number( $order_post->ID, $order_post );
+			if ( $order ) {
+				$this->set_sequential_order_number( $order->get_id(), $order );
+			}
 		}
 
-		// after Subs 2.0 this callback needs to return the renewal order
 		return $renewal_order;
 	}
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -197,12 +197,13 @@ class WC_Seq_Order_Number {
 			if ( $this->is_hpos_enabled() ) {
 				/** @see \Automattic\WooCommerce\Internal\Admin\Orders\ListTable::prepare_items() */
 				add_filter( 'woocommerce_shop_order_list_table_request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
-				add_filter( 'woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_admin_order_table_search_by_order_number' ], 30 );
 			} else {
 				add_filter( 'request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
 			}
 
-			add_filter( 'woocommerce_shop_order_search_fields', array( $this, 'custom_search_fields' ) );
+			// ensure that admin order table search by order number works
+			add_filter( 'woocommerce_shop_order_search_fields', [ $this, 'custom_search_fields' ] );
+			add_filter( 'woocommerce_order_table_search_query_meta_keys', [ $this, 'custom_search_fields'] );
 
 			// sort by underlying _order_number on the Pre-Orders table
 			add_filter( 'wc_pre_orders_edit_pre_orders_request', array( $this, 'custom_orderby' ) );
@@ -413,45 +414,6 @@ class WC_Seq_Order_Number {
 		}
 
 		return $this->custom_orderby( $vars );
-	}
-
-	/**
-	 * Filters the order args when searching by order ID.
-	 *
-	 * @since 1.10.0-dev.1
-	 *
-	 * @internal
-	 *
-	 * @param array<string, mixed>|mixed $order_args
-	 * @return array<string, mixed>|mixed
-	 */
-	public function filter_admin_order_table_search_by_order_number( $order_args ) {
-
-		if ( ! is_array( $order_args ) ) {
-			return $order_args;
-		}
-
-		if ( isset( $order_args['s'] ) && is_numeric( $order_args['s'] ) ) {
-
-			$order = wc_get_orders( [
-				'return'     => 'ids',
-				'limit'      => 1,
-				'meta_query' => [
-					[
-						'key'     => '_order_number',
-						'value'   => $order_args['s'],
-						'compare' => '='
-					],
-				]
-			] );
-
-			// if we find an order matching the order number from search, let's use this order ID instead
-			if ( $order ) {
-				$order_args['s'] = $order[0];
-			}
-		}
-
-		return $order_args;
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -54,6 +54,27 @@ class WC_Seq_Order_Number {
 
 		add_action( 'plugins_loaded', array( $this, 'initialize' ) );
 		add_action( 'init',           array( $this, 'load_translation' ) );
+
+
+		// handle HPOS compatibility
+		add_action( 'before_woocommerce_init', [ $this, 'handle_hpos_compatibility' ] );
+	}
+
+
+	/**
+	 * Declares HPOS compatibility.
+	 *
+	 * @since 1.10.0-dev.1
+	 *
+	 * @internal
+	 *
+	 * @return void
+	 */
+	public function handle_hpos_compatibility()
+	{
+		if ( class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', plugin_basename( __FILE__ ), true );
+		}
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -349,20 +349,7 @@ class WC_Seq_Order_Number {
 					", (int) $order_id ) );
 				}
 
-				// With HPOS we need to trigger a save to update the order number or it won't persist by using the direct query above alone.
-				// This may have the effect of creating 2 identical order number meta entries for an order but this seems to work nonetheless.
-				if ( $success && $using_hpos ) {
-
-					$meta_id_col  = 'id';
-					$order_number = $wpdb->get_var( $wpdb->prepare( "
-						SELECT meta_value
-						FROM {$order_meta_table}
-						WHERE {$meta_id_col} = %d
-					", $wpdb->insert_id ) );
-
-					$order->update_meta_data( '_order_number', $order_number );
-				}
-
+				// with HPOS we need to trigger a save to update the order number or it won't persist by using the direct query above alone
 				$order->save();
 			}
 		}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -197,7 +197,7 @@ class WC_Seq_Order_Number {
 			if ( $this->is_hpos_enabled() ) {
 				/** @see \Automattic\WooCommerce\Internal\Admin\Orders\ListTable::prepare_items() */
 				add_filter( 'woocommerce_shop_order_list_table_request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
-				add_filter( 'woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_admin_order_table_search_by_order_number' ] );
+				add_filter( 'woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_admin_order_table_search_by_order_number' ], 30 );
 			} else {
 				add_filter( 'request', [ $this, 'woocommerce_custom_shop_order_orderby' ], 20 );
 			}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -369,6 +369,11 @@ class WC_Seq_Order_Number {
 	 */
 	public function get_order_number( $order_number, $order ) {
 
+		// don't display an order number for subscription objects
+		if ( $order instanceof \WC_Subscription ) {
+			return $order_number;
+		}
+
 		if ( $sequential_order_number = $order->get_meta( '_order_number', true, 'edit' ) ) {
 			$order_number = $sequential_order_number;
 		}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -131,10 +131,12 @@ class WC_Seq_Order_Number {
 			return;
 		}
 
-		// Set the custom order number on the new order.  we hook into wp_insert_post for orders which are created
-		// from the frontend, and we hook into woocommerce_process_shop_order_meta for admin-created orders
-		add_action( 'wp_insert_post', array( $this, 'set_sequential_order_number' ), 10, 2 );
-		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'set_sequential_order_number' ), 10, 2 );
+		// Set the custom order number on the new order.
+		// We hook into 'woocommerce_checkout_update_order_meta' for orders which are created from the frontend, and we hook into 'woocommerce_process_shop_order_meta' for admin-created orders.
+		// Note we use these actions rather than the more generic 'wp_insert_post' action because we want to run after the order meta (including totals) are set, so we can detect whether this is a free order.
+		add_action( 'woocommerce_checkout_update_order_meta', [ $this, 'set_sequential_order_number' ], 10, 2 );
+		add_action( 'woocommerce_process_shop_order_meta',    [ $this, 'set_sequential_order_number' ], 35, 2 );
+		add_action( 'woocommerce_before_resend_order_emails', [ $this, 'set_sequential_order_number' ], 10, 1 );
 
 		// return our custom order number for display
 		add_filter( 'woocommerce_order_number', array( $this, 'get_order_number' ), 10, 2 );

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -52,9 +52,8 @@ class WC_Seq_Order_Number {
 	 */
 	public function __construct() {
 
-		add_action( 'plugins_loaded', array( $this, 'initialize' ) );
-		add_action( 'init',           array( $this, 'load_translation' ) );
-
+		add_action( 'plugins_loaded', [ $this, 'initialize' ] );
+		add_action( 'init',           [ $this, 'load_translation' ] );
 
 		// handle HPOS compatibility
 		add_action( 'before_woocommerce_init', [ $this, 'handle_hpos_compatibility' ] );

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -121,7 +121,7 @@ class WC_Seq_Order_Number {
 		return $orders_screen_id === $current_screen->id
 			&& isset( $_GET['page'] )
 			&& $_GET['page'] === 'wc-orders'
-			&& ! in_array( $_GET['action'], [ 'new', 'edit' ], true );
+			&& ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], [ 'new', 'edit' ], true ) );
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -116,8 +116,11 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Initialize the plugin, bailing if any required conditions are not met,
-	 * including minimum WooCommerce version
+	 * Initialize the plugin.
+	 *
+	 * Prevents loading if any required conditions are not met, including minimum WooCommerce version.
+	 *
+	 * @internal
 	 *
 	 * @since 1.3.2
 	 */
@@ -166,7 +169,9 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Load Translations
+	 * Loads translations.
+	 *
+	 * @internal
 	 *
 	 * @since 1.3.3
 	 */
@@ -179,6 +184,8 @@ class WC_Seq_Order_Number {
 
 	/**
 	 * Search for an order with order_number $order_number
+	 *
+	 * @since 1.0.0
 	 *
 	 * @param string $order_number order number to search for
 	 * @return int post_id for the order identified by $order_number, or 0
@@ -305,8 +312,9 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Filter to return our _order_number field rather than the post ID,
-	 * for display.
+	 * Filters to return our _order_number field rather than the post ID, for display.
+	 *
+	 * @since 1.0.0
 	 *
 	 * @param string $order_number the order id with a leading hash
 	 * @param \WC_Order $order the order object
@@ -474,10 +482,12 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Main Sequential Order Numbers Instance, ensures only one instance is/can be loaded
+	 * Main Sequential Order Numbers Instance, ensures only one instance is/can be loaded.
+	 *
+	 * @see wc_sequential_order_numbers()
 	 *
 	 * @since 1.7.0
-	 * @see wc_sequential_order_numbers()
+	 *
 	 * @return \WC_Seq_Order_Number
 	 */
 	public static function instance() {
@@ -532,9 +542,10 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Helper method to get the version of the currently installed WooCommerce
+	 * Helper method to get the version of the currently installed WooCommerce.
 	 *
 	 * @since 1.3.2
+	 *
 	 * @return string woocommerce version number or null
 	 */
 	private static function get_wc_version() {
@@ -543,10 +554,11 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Perform a minimum WooCommerce version check
+	 * Performs a minimum WooCommerce version check.
 	 *
 	 * @since 1.3.2
-	 * @return boolean true if the required version is met, false otherwise
+	 *
+	 * @return bool
 	 */
 	private function minimum_wc_version_met() {
 
@@ -568,7 +580,9 @@ class WC_Seq_Order_Number {
 
 
 	/**
-	 * Render a notice to update WooCommerce if needed
+	 * Renders a notice to update WooCommerce if needed
+	 *
+	 * @internal
 	 *
 	 * @since 1.3.2
 	 */
@@ -672,6 +686,7 @@ class WC_Seq_Order_Number {
  * Returns the One True Instance of Sequential Order Numbers
  *
  * @since 1.7.0
+ *
  * @return \WC_Seq_Order_Number
  */
 function wc_sequential_order_numbers() {

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.7
+ * Version: 1.10.0-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.7';
+	const VERSION = '1.10.0-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.9.4';

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -471,7 +471,7 @@ class WC_Seq_Order_Number {
 	 */
 	public function custom_search_fields( $search_fields ) {
 
-		return array_merge( (array) $search_fields, [ '_order_number', 'order_number' ] );
+		return array_merge( (array) $search_fields, [ '_order_number' ] );
 	}
 
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -296,7 +296,7 @@ class WC_Seq_Order_Number {
 	 * @since 1.0.0
 	 *
 	 * @param int|\WC_Order $order_id order identifier or order object
-	 * @param \WP_Post|\WC_Order|null $object order or post object (depending on whether HPOS is in use or not)
+	 * @param \WP_Post|\WC_Order|array<string, mixed>null $object order or post object or post data (depending on HPOS and hook in use)
 	 */
 	public function set_sequential_order_number( $order_id = null, $object = null ) {
 		global $wpdb;
@@ -309,12 +309,6 @@ class WC_Seq_Order_Number {
 			$order        = $is_order ? wc_get_order( $object->ID ) : null;
 			$order_id     = $object->ID;
 			$order_status = $object->post_status;
-
-		} elseif ( null === $object && $order_id ) {
-
-			$order        = wc_get_order( $order_id );
-			$is_order     = $order instanceof \WC_Order;
-			$order_status = $order ? $order->get_status() : '';
 
 		} else {
 
@@ -330,7 +324,7 @@ class WC_Seq_Order_Number {
 
 		// when creating an order from the admin don't create order numbers for auto-draft orders,
 		// because these are not linked to from the admin and so difficult to delete when CPT tables are used
-		if ( $object === null || ( $is_order && ( $using_hpos || 'auto-draft' !== $order_status ) ) ) {
+		if ( $is_order && ( $using_hpos || 'auto-draft' !== $order_status ) ) {
 
 			if ( $using_hpos ) {
 				$order_number = $order ? $order->get_meta( '_order_number' ) : '';
@@ -338,7 +332,7 @@ class WC_Seq_Order_Number {
 				$order_number = get_post_meta( $order_id, '_order_number', true );
 			}
 
-			// if no order number has been assigned, this will be an empty array
+			// if no order number has been assigned, create one
 			if ( empty( $order_number ) ) {
 
 				// attempt the query up to 3 times for a much higher success rate if it fails (to avoid deadlocks)

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -387,13 +387,15 @@ class WC_Seq_Order_Number {
 	 *
 	 * @since 1.3
 	 *
+	 * @internal
+	 *
 	 * @param \WC_Order $renewal_order the new renewal order object
 	 * @param \WC_Subscription $subscription Post ID of a 'shop_subscription' post, or instance of a WC_Subscription object
 	 * @return \WC_Order renewal order instance
 	 */
 	public function subscriptions_set_sequential_order_number( $renewal_order, $subscription ) {
 
-		if ( $renewal_order instanceof WC_Order ) {
+		if ( $renewal_order instanceof \WC_Order ) {
 
 			$order = wc_get_order( $renewal_order->get_id() );
 
@@ -409,11 +411,13 @@ class WC_Seq_Order_Number {
 	/**
 	 * Don't copy over order number meta when creating a parent or child renewal order
 	 *
-	 * Prevents unnecessary order meta from polluting parent renewal orders,
-	 * and set order number for subscription orders
+	 * Prevents unnecessary order meta from polluting parent renewal orders, and set order number for subscription orders.
 	 *
 	 * @since 1.3
-	 * @param array $order_meta_query query for pulling the metadata
+	 *
+	 * @internal
+	 *
+	 * @param string $order_meta_query query for pulling the metadata
 	 * @return string
 	 */
 	public function subscriptions_remove_renewal_order_meta( $order_meta_query ) {
@@ -421,7 +425,11 @@ class WC_Seq_Order_Number {
 	}
 
 	/**
-	 * Hook WooCommerce Admin's order number search to the meta value.
+	 * Hook WooCommerce Admin  order number search to the meta value.
+	 *
+	 * @since 1.3
+	 *
+	 * @internal
 	 *
 	 * @param array $args Arguments to be passed to WC_Order_Query.
 	 * @param WP_REST_Request $request REST API request being made.

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -356,8 +356,20 @@ class WC_Seq_Order_Number {
 					", (int) $order_id ) );
 				}
 
-				// with HPOS we need to trigger a save to update the order number, otherwise it won't persist by using the direct query above alone
-				$order->save();
+				// With HPOS we need to trigger a save to update the order number or it won't persist by using the direct query above alone.
+				// This may have the effect of creating 2 identical order number meta entries for an order but this seems to work nonetheless.
+				if ( $success && $using_hpos ) {
+
+					$meta_id_col  = 'id';
+					$order_number = $wpdb->get_var( $wpdb->prepare( "
+						SELECT meta_value
+						FROM {$order_meta_table}
+						WHERE {$meta_id_col} = %d
+					", $wpdb->insert_id ) );
+
+					$order->update_meta_data( '_order_number', $order_number );
+					$order->save();
+				}
 			}
 		}
 	}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2012-2023, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
+ * @copyright Copyright (c) 2012-2023, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4


### PR DESCRIPTION
## Summary

Adds support to HPOS in the free Sequential Order Numbers as per [discovery doc](https://docs.google.com/document/d/1752eyK4-9d-bxlOc2ZbAbZqEk91O5aPPrZHC-U0ovYE/edit#bookmark=id.gs1nmr6olztf).


### Story: [MWC-11024](https://godaddy-corp.atlassian.net/browse/MWC-11024)

#### Closes #30 
#### Closes #31


Note that unlike other free plugins, SON has more compatibility code changes and needs a full QA in both CPT and HPOS scenarios.

This PR includes a change from #32:

- [ ] To test the WC Checkout Block, install the [WooCommerce Blocks](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) plugin, [follow these instructions to set it up](https://woocommerce.com/document/using-the-new-block-based-checkout/) and place an order while SONP is active -- the SON number should be set also for orders sent this way.


⚠️ ✅  ~~While QA'ing this I noticed some issues that I did not recall while we updated the paid version, so I tested that and noticed that unfortunately some recent WC version may have broken the compatibility code we added a while ago: https://github.com/gdcorp-partners/woocommerce-sequential-order-numbers-pro/pull/75~~