### PR TITLE
Release: v1.10.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,9 @@ $order_number = $order->get_order_number();
 
 == Changelog ==
 
+- 2023.nn.nn - version 1.10.1-dev.1 =
+ * Fix - Call save order method only in HPOS installs to avoid setting the same order number meta twice in CPT installations
+
 - 2023.08.02 - version 1.10.0 =
  * Tweak - Also set sequential order numbers for orders sent via the WooCommerce Checkout Block
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 5.6
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Stable tag: 1.10.0
+Stable tag: 1.10.1-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.10.0
+ * Version: 1.10.1-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.10.0';
+	const VERSION = '1.10.1-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.9.4';
@@ -351,8 +351,11 @@ class WC_Seq_Order_Number {
 					", (int) $order_id ) );
 				}
 
-				// with HPOS we need to trigger a save to update the order number or it won't persist by using the direct query above alone
-				$order->save();
+				// with HPOS we need to trigger a save to update the order number,
+				// or it won't persist by using the direct query above alone
+				if ( $using_hpos ) {
+					$order->save();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This update fixes #34.

- [ ] To replicate the issue, on a site running WooCommerce using CPT (non-HPOS), try setting orders using the plugin. You'll notice duplicate post metas. 
- [x] Then, switch to this branch: you should see only one post meta set. 

In HPOS we need to call `WC_Order::save()` due to a known race condition.