### PR TITLE
Bump tested-up-to to WordPress 6.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 5.6
-Tested up to: 6.6.2
+Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 1.11.0
 License: GPLv3 or later


### PR DESCRIPTION
Already bumped on dotorg: https://plugins.trac.wordpress.org/changeset/3279478/