### PR TITLE
Release: v1.11.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.11.0
+Stable tag: 1.11.1-dev.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -103,6 +103,8 @@ $order_number = $order->get_order_number();
 `
 
 == Changelog ==
+
+= 2025.nn.nn - version 1.11.1-dev.1 =
 
 = 2024.11.06 - version 1.11.0 =
  * Misc - Code clean up and optimization

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.11.0
+ * Version: 1.11.1-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -36,7 +36,7 @@ class WC_Seq_Order_Number {
 
 
 	/** Version number */
-	public const VERSION = '1.11.0';
+	public const VERSION = '1.11.1-dev.1';
 
 	/** Minimum required wc version */
 	public const MINIMUM_WC_VERSION = '3.9.4';


### PR DESCRIPTION
## Stories

- https://github.com/godaddy-wordpress/woocommerce-sequential-order-numbers/pull/42

## Before merge

- [x] Smoke screen with generated zip