### PR TITLE
Add support for searching by order ID with full text search

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ $order_number = $order->get_order_number();
 == Changelog ==
 
 = 2025.nn.nn - version 1.11.1-dev.1 =
+ * Fix - Searching by order number not working when Full Text Search is enabled
 
 = 2024.11.06 - version 1.11.0 =
  * Misc - Code clean up and optimization


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-17929
Release: https://github.com/godaddy-wordpress/woocommerce-sequential-order-numbers/pull/41

# Summary

This adds support for searching by sequential order number when Full Text Search is enabled.

## QA

1. Go to WooCommerce > Settings > Advanced > Features.
2. Enable "HPOS full text search indexes"
3. Go to WooCommerce > Orders and find a sequential order in the list. Copy its ID.
4. Paste the sequential order number into the search field and search.
    - [x] You get one result: the exact order you searched for.
5. Adjust the search so its a partial match. e.g. if your order number is `SV-125`, adjust the search so that it says `SV-12`.
    - [x] You see multiple results matching that query (e.g. any order number that's `%SV-12%`
6. Disable full text search.
7. Repeat the same searches as before.
    - [x] Results match / are as expected (behaviour should be the same)